### PR TITLE
Epic login component validate

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,20 +7,29 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 
     <application
-        android:name=".LogIn.TrainingApplication"
+        android:name=".training.TrainingApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:theme="@style/AppTheme">
 
         <activity
-            android:name=".LogIn.ui.login.LogInActivity"
+            android:name=".training.ui.RootActivity"
             android:screenOrientation="portrait">
 
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+        </activity>
 
+        <activity
+            android:name=".training.ui.login.LogInActivity"
+            android:screenOrientation="portrait">
+        </activity>
+
+        <activity
+            android:name=".training.ui.home.HomeActivity"
+            android:screenOrientation="portrait">
         </activity>
 
     </application>

--- a/app/src/main/java/ar/com/wolox/android/LogIn/BaseConfiguration.java
+++ b/app/src/main/java/ar/com/wolox/android/LogIn/BaseConfiguration.java
@@ -1,7 +1,13 @@
 package ar.com.wolox.android.LogIn;
 
+import android.graphics.drawable.Drawable;
+
 class BaseConfiguration {
 
     public static final String EXAMPLE_CONFIGURAITON_KEY = "com.example.test.test";
+
+    public void setError(CharSequence error, Drawable icon){
+
+    }
 
 }

--- a/app/src/main/java/ar/com/wolox/android/LogIn/LogInRetrofitServices.java
+++ b/app/src/main/java/ar/com/wolox/android/LogIn/LogInRetrofitServices.java
@@ -32,4 +32,6 @@ public class LogInRetrofitServices extends RetrofitServices {
             builder.addInterceptor(new ChuckInterceptor(TrainingApplication.getInstance()));
         }
     }
+
+
 }

--- a/app/src/main/java/ar/com/wolox/android/LogIn/ui/login/LogInActivity.java
+++ b/app/src/main/java/ar/com/wolox/android/LogIn/ui/login/LogInActivity.java
@@ -15,4 +15,6 @@ public class LogInActivity extends WolmoActivity {
     protected void init() {
         replaceFragment(R.id.activity_base_content, LogInFragment.newInstance());
     }
+
+
 }

--- a/app/src/main/java/ar/com/wolox/android/LogIn/ui/login/LogInFragment.java
+++ b/app/src/main/java/ar/com/wolox/android/LogIn/ui/login/LogInFragment.java
@@ -1,8 +1,11 @@
 package ar.com.wolox.android.LogIn.ui.login;
 
+import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.text.method.LinkMovementMethod;
 import android.view.View;
+import android.widget.Button;
+import android.widget.EditText;
 import android.widget.TextView;
 
 import ar.com.wolox.android.R;
@@ -14,6 +17,8 @@ import butterknife.OnClick;
 public class LogInFragment extends WolmoFragment<LogInPresenter> implements LogInView {
 
     @BindView(R.id.fragment_login_terms) TextView mTermsTxt;
+    @BindView(R.id.fragment_login_email_address_edit_text) EditText mEmailTxt;
+    //@BindView(R.id.fragment_login_login_button) Button mLogInBtn;
 
     // Fragments default constructors shouldn't be overridden, always prefer this method instead
     public static LogInFragment newInstance() {
@@ -21,6 +26,16 @@ public class LogInFragment extends WolmoFragment<LogInPresenter> implements LogI
         LogInFragment fragment = new LogInFragment();
         fragment.setArguments(args);
         return fragment;
+    }
+
+
+    @OnClick(R.id.fragment_login_login_button)
+        public void LogInValidate(){
+            if (mEmailTxt.length() == 0) {
+                mEmailTxt.setError("Please complete your email address");
+            }else if (!android.util.Patterns.EMAIL_ADDRESS.matcher(mEmailTxt.getText()).matches()){
+                    mEmailTxt.setError("Please insert a valid email address");
+            }
     }
 
     @Override
@@ -42,5 +57,8 @@ public class LogInFragment extends WolmoFragment<LogInPresenter> implements LogI
     @Override
     public void init() {
     }
+
+
+
 
 }

--- a/app/src/main/java/ar/com/wolox/android/LogIn/ui/login/LogInView.java
+++ b/app/src/main/java/ar/com/wolox/android/LogIn/ui/login/LogInView.java
@@ -1,4 +1,0 @@
-package ar.com.wolox.android.LogIn.ui.login;
-
-public interface LogInView {
-}

--- a/app/src/main/java/ar/com/wolox/android/training/BaseConfiguration.java
+++ b/app/src/main/java/ar/com/wolox/android/training/BaseConfiguration.java
@@ -1,4 +1,4 @@
-package ar.com.wolox.android.LogIn;
+package ar.com.wolox.android.training;
 
 import android.graphics.drawable.Drawable;
 

--- a/app/src/main/java/ar/com/wolox/android/training/LogInRetrofitServices.java
+++ b/app/src/main/java/ar/com/wolox/android/training/LogInRetrofitServices.java
@@ -1,4 +1,4 @@
-package ar.com.wolox.android.LogIn;
+package ar.com.wolox.android.training;
 
 import android.support.annotation.NonNull;
 

--- a/app/src/main/java/ar/com/wolox/android/training/TrainingApplication.java
+++ b/app/src/main/java/ar/com/wolox/android/training/TrainingApplication.java
@@ -1,4 +1,4 @@
-package ar.com.wolox.android.LogIn;
+package ar.com.wolox.android.training;
 
 import com.squareup.leakcanary.LeakCanary;
 

--- a/app/src/main/java/ar/com/wolox/android/training/ui/RootActivity.java
+++ b/app/src/main/java/ar/com/wolox/android/training/ui/RootActivity.java
@@ -1,0 +1,41 @@
+package ar.com.wolox.android.training.ui;
+
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+
+import ar.com.wolox.android.R;
+import ar.com.wolox.android.training.ui.home.HomeActivity;
+import ar.com.wolox.android.training.ui.login.LogInActivity;
+import ar.com.wolox.wolmo.core.activity.WolmoActivity;
+
+public class RootActivity extends WolmoActivity {
+
+    private static final String USER = "USER";
+    private static final String DefaultUSER = "DefaultUser";
+
+    @Override
+    protected int layout() {
+        return R.layout.activity_base;
+    }
+
+    @Override
+    protected void init() {
+        SharedPreferences sharedPref = this.getSharedPreferences(USER,Context.MODE_PRIVATE);
+        String userKey = sharedPref.getString(USER,DefaultUSER);
+        if (userKey.equals(DefaultUSER)) {
+            // Call LogInActivity
+            Intent logInIntent = new Intent(this, LogInActivity.class);
+            logInIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+            startActivity(logInIntent);
+            finish();
+        }else {
+            // Call HomeActivity
+            Intent homeIntent = new Intent(this, HomeActivity.class);
+            homeIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+            startActivity(homeIntent);
+            finish();
+        }
+    }
+}

--- a/app/src/main/java/ar/com/wolox/android/training/ui/home/HomeActivity.java
+++ b/app/src/main/java/ar/com/wolox/android/training/ui/home/HomeActivity.java
@@ -1,0 +1,20 @@
+package ar.com.wolox.android.training.ui.home;
+
+
+import ar.com.wolox.android.R;
+import ar.com.wolox.wolmo.core.activity.WolmoActivity;
+
+public class HomeActivity extends WolmoActivity {
+
+    @Override
+    protected int layout() {
+        return R.layout.activity_base;
+    }
+
+    @Override
+    protected void init() {
+        replaceFragment(R.id.activity_base_content, HomeFragment.newInstance());
+    }
+
+
+}

--- a/app/src/main/java/ar/com/wolox/android/training/ui/home/HomeFragment.java
+++ b/app/src/main/java/ar/com/wolox/android/training/ui/home/HomeFragment.java
@@ -1,0 +1,40 @@
+package ar.com.wolox.android.training.ui.home;
+
+import android.os.Bundle;
+import android.view.View;
+
+import ar.com.wolox.android.R;
+import ar.com.wolox.wolmo.core.fragment.WolmoFragment;
+
+public class HomeFragment extends WolmoFragment<HomePresenter> implements HomeView {
+
+    public static HomeFragment newInstance() {
+        Bundle args = new Bundle();
+        HomeFragment fragment = new HomeFragment();
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    public int layout() {
+        return R.layout.fragment_home;
+    }
+
+    @Override
+    public void setUi(View v) {
+        super.setUi(v);
+    }
+
+    @Override
+    public HomePresenter createPresenter() {
+        return new HomePresenter(this);
+    }
+
+    @Override
+    public void init() {
+    }
+
+
+
+
+}

--- a/app/src/main/java/ar/com/wolox/android/training/ui/home/HomePresenter.java
+++ b/app/src/main/java/ar/com/wolox/android/training/ui/home/HomePresenter.java
@@ -1,0 +1,14 @@
+package ar.com.wolox.android.training.ui.home;
+
+
+import ar.com.wolox.wolmo.core.presenter.BasePresenter;
+
+public class HomePresenter extends BasePresenter<HomeView> {
+
+    // Constructor
+    public HomePresenter(HomeView viewInstance) {
+        super(viewInstance);
+    }
+
+
+}

--- a/app/src/main/java/ar/com/wolox/android/training/ui/home/HomeView.java
+++ b/app/src/main/java/ar/com/wolox/android/training/ui/home/HomeView.java
@@ -1,0 +1,4 @@
+package ar.com.wolox.android.training.ui.home;
+
+public interface HomeView {
+}

--- a/app/src/main/java/ar/com/wolox/android/training/ui/login/LogInActivity.java
+++ b/app/src/main/java/ar/com/wolox/android/training/ui/login/LogInActivity.java
@@ -1,4 +1,4 @@
-package ar.com.wolox.android.LogIn.ui.login;
+package ar.com.wolox.android.training.ui.login;
 
 
 import ar.com.wolox.android.R;

--- a/app/src/main/java/ar/com/wolox/android/training/ui/login/LogInFragment.java
+++ b/app/src/main/java/ar/com/wolox/android/training/ui/login/LogInFragment.java
@@ -1,24 +1,25 @@
-package ar.com.wolox.android.LogIn.ui.login;
+package ar.com.wolox.android.training.ui.login;
 
-import android.graphics.drawable.Drawable;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.text.method.LinkMovementMethod;
 import android.view.View;
-import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
 
 import ar.com.wolox.android.R;
+import ar.com.wolox.android.training.ui.home.HomeActivity;
 import ar.com.wolox.wolmo.core.fragment.WolmoFragment;
-import butterknife.BindString;
 import butterknife.BindView;
 import butterknife.OnClick;
 
 public class LogInFragment extends WolmoFragment<LogInPresenter> implements LogInView {
 
+    private static final String USER = "USER";
     @BindView(R.id.fragment_login_terms) TextView mTermsTxt;
     @BindView(R.id.fragment_login_email_address_edit_text) EditText mEmailTxt;
-    //@BindView(R.id.fragment_login_login_button) Button mLogInBtn;
 
     // Fragments default constructors shouldn't be overridden, always prefer this method instead
     public static LogInFragment newInstance() {
@@ -35,8 +36,19 @@ public class LogInFragment extends WolmoFragment<LogInPresenter> implements LogI
                 mEmailTxt.setError("Please complete your email address");
             }else if (!android.util.Patterns.EMAIL_ADDRESS.matcher(mEmailTxt.getText()).matches()){
                     mEmailTxt.setError("Please insert a valid email address");
+            }else{
+                SharedPreferences sharedPref = getActivity().getSharedPreferences(USER,Context.MODE_PRIVATE);
+                SharedPreferences.Editor editor = sharedPref.edit();
+                editor.putString(USER, mEmailTxt.getText().toString());
+                editor.commit();
+                Intent homeIntent = new Intent(getActivity(), HomeActivity.class);
+                homeIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+                startActivity(homeIntent);
+                getActivity().finish();
             }
+
     }
+
 
     @Override
     public int layout() {

--- a/app/src/main/java/ar/com/wolox/android/training/ui/login/LogInPresenter.java
+++ b/app/src/main/java/ar/com/wolox/android/training/ui/login/LogInPresenter.java
@@ -1,4 +1,4 @@
-package ar.com.wolox.android.LogIn.ui.login;
+package ar.com.wolox.android.training.ui.login;
 
 
 import ar.com.wolox.wolmo.core.presenter.BasePresenter;

--- a/app/src/main/java/ar/com/wolox/android/training/ui/login/LogInView.java
+++ b/app/src/main/java/ar/com/wolox/android/training/ui/login/LogInView.java
@@ -1,0 +1,4 @@
+package ar.com.wolox.android.training.ui.login;
+
+public interface LogInView {
+}

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"/>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout
+<LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"/>
+    android:layout_height="match_parent">
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:text="HOME"/>
+
+</LinearLayout>
+

--- a/app/src/main/res/layout/fragment_login.xml
+++ b/app/src/main/res/layout/fragment_login.xml
@@ -21,7 +21,7 @@
             android:background="@drawable/login_cover_grad_colour"
             android:scaleType="centerCrop"
             android:src="@drawable/login_cover"
-            android:alpha="0.4"
+            android:alpha="0.3"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintHorizontal_bias="0.0"
             app:layout_constraintLeft_toLeftOf="parent"

--- a/app/src/production/java/ar/com/wolox/android/training/Configuration.java
+++ b/app/src/production/java/ar/com/wolox/android/training/Configuration.java
@@ -1,4 +1,4 @@
-package ar.com.wolox.android.LogIn;
+package ar.com.wolox.android.training;
 
 public class Configuration extends BaseConfiguration {
     public static final String API_ENDPOINT = "http://api.wolox.com.ar";

--- a/app/src/stage/java/ar/com/wolox/android/example/Configuration.java
+++ b/app/src/stage/java/ar/com/wolox/android/example/Configuration.java
@@ -1,4 +1,4 @@
-package ar.com.wolox.android.LogIn;
+package ar.com.wolox.android.training;
 
 public class Configuration extends BaseConfiguration {
     public static final String API_ENDPOINT = "http://stage.api.wolox.com.ar";

--- a/app/src/test/java/ar/com/wolox/android/LogIn/LogInPresenterTest.java
+++ b/app/src/test/java/ar/com/wolox/android/LogIn/LogInPresenterTest.java
@@ -1,5 +1,3 @@
 package ar.com.wolox.android.LogIn;
 
-import android.content.Context;
-
 public class LogInPresenterTest {}

--- a/app/src/test/java/ar/com/wolox/android/LogIn/LogInPresenterTest.java
+++ b/app/src/test/java/ar/com/wolox/android/LogIn/LogInPresenterTest.java
@@ -1,3 +1,0 @@
-package ar.com.wolox.android.LogIn;
-
-public class LogInPresenterTest {}

--- a/app/src/test/java/ar/com/wolox/android/training/LogInPresenterTest.java
+++ b/app/src/test/java/ar/com/wolox/android/training/LogInPresenterTest.java
@@ -1,0 +1,3 @@
+package ar.com.wolox.android.training;
+
+public class LogInPresenterTest {}


### PR DESCRIPTION
### Summary
Root and Home activities were created. App starts in RootActivity and will try to load USER key-value. If this is done succesfully HomeActivity is called, unless DefaultUSER is created and LogInActivity starts. In both cases the back button stack is being cleaned. 
In LogInActivity, email address validation was incorporated. If edit text is empty or filled with wrong email pattern displays error message. If a correct email has been inserted, HomeActivity is called.

### Screenshot
![image](https://user-images.githubusercontent.com/36635668/36794095-2da8f73a-1c7e-11e8-9d77-e4f6617c532c.png)

### Trello Card
https://trello.com/c/hqlPikme/19-u1-frontend-login-validaciones